### PR TITLE
Fix an unresolved placeholder

### DIFF
--- a/aosabook.org/en/intro2.html
+++ b/aosabook.org/en/intro2.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../bootstrap/css/bootstrap.css" type="text/css">
     <link rel="stylesheet" href="../bootstrap/css/bootstrap-responsive.css" type="text/css">
     <link rel="stylesheet" href="aosa.css" type="text/css">
-    <title>The Architecture of Open Source Applications (Volume 2): $TITLE</title>
+    <title>The Architecture of Open Source Applications (Volume 2): Introduction</title>
   </head>
   <body>
 


### PR DESCRIPTION
`$TITLE` is in the `<title>` of the page. Based on http://aosabook.org/en/posa/introduction.html and http://aosabook.org/en/intro1.html, I'm assuming that $TITLE should be Introduction.
