### PR TITLE
Fix hyperref

### DIFF
--- a/v1/tex/en/aosa.tex
+++ b/v1/tex/en/aosa.tex
@@ -2,8 +2,7 @@
 
 \usepackage{graphicx}
 \usepackage{epstopdf}
-\usepackage{url} % this package doesn't make proper clickable links, but
-% \usepackage{hyperref} % this package breaks the build.
+\usepackage{hyperref}
 \usepackage{microtype}
 \usepackage{amssymb}
 \usepackage{framed} % for sidebars
@@ -21,6 +20,13 @@
 \usepackage{tgheros}     % sans-serif font
 
 \author{Amy Brown \& Greg Wilson}
+
+\hypersetup{
+    colorlinks=true,
+    urlcolor=blue,
+    linkcolor=black,
+    citecolor=red
+}
 
 % define page size and margins etc
 \geometry{paperwidth=18.91cm,paperheight=24.589cm,

--- a/v1/tex/ja/aosa.tex
+++ b/v1/tex/ja/aosa.tex
@@ -3,8 +3,7 @@
 
 \usepackage{graphicx}
 \usepackage{epstopdf}
-\usepackage{url} % this package doesn't make proper clickable links, but
-% \usepackage{hyperref} % this package breaks the build.
+\usepackage{hyperref}
 \usepackage{microtype}
 \usepackage{amssymb}
 \usepackage{framed} % for sidebars
@@ -22,6 +21,13 @@
 \usepackage{tgheros}     % sans-serif font
 
 \author{Amy Brown \& Greg Wilson}
+
+\hypersetup{
+    colorlinks=true,
+    urlcolor=blue,
+    linkcolor=black,
+    citecolor=red
+}
 
 % define page size and margins etc
 \geometry{paperwidth=18.91cm,paperheight=24.589cm,

--- a/v2/tex/en/aosa2.tex
+++ b/v2/tex/en/aosa2.tex
@@ -2,8 +2,7 @@
 
 \usepackage{graphicx}
 \usepackage{epstopdf}
-\usepackage[hyphens]{url} % this package doesn't make proper clickable links, but
-% \usepackage{hyperref} % this package breaks the build.
+\usepackage{hyperref}
 \usepackage{microtype}
 \usepackage{amssymb}
 \usepackage{framed} % for sidebars
@@ -27,6 +26,13 @@
 \usepackage{tgheros}     % sans-serif font
 
 \author{Amy Brown \& Greg Wilson}
+
+\hypersetup{
+    colorlinks=true,
+    urlcolor=blue,
+    linkcolor=black,
+    citecolor=red
+}
 
 % define page size and margins etc
 \geometry{paperwidth=18.91cm,paperheight=24.589cm,

--- a/v2/tex/en/aosa2PDF.tex
+++ b/v2/tex/en/aosa2PDF.tex
@@ -2,8 +2,7 @@
 
 \usepackage{graphicx}
 \usepackage{epstopdf}
-\usepackage[hyphens]{url} % this package doesn't make proper clickable links, but
-% \usepackage{hyperref} % this package breaks the build.
+\usepackage{hyperref}
 \usepackage{microtype}
 \usepackage{amssymb}
 \usepackage{framed} % for sidebars
@@ -27,6 +26,13 @@
 \usepackage{tgheros}     % sans-serif font
 
 \author{Amy Brown \& Greg Wilson}
+
+\hypersetup{
+    colorlinks=true,
+    urlcolor=blue,
+    linkcolor=black,
+    citecolor=red
+}
 
 % define page size and margins etc
 \geometry{paperwidth=18.91cm,paperheight=24.589cm,

--- a/v2/tex/en/nginx.tex
+++ b/v2/tex/en/nginx.tex
@@ -531,7 +531,7 @@ try/match against different URI-to-content mappings. Overall, the
 and useful. It is recommended that the reader thoroughly check the
 \code{try\_files} directive and adopt its use whenever
 applicable\footnote{See
-  \url{http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files}
+  \url{http://nginx.org/en/docs/http/ngx_http_core_module.html\#try_files}
   for more details.}.
 
 \end{aosasect1}

--- a/v2/tex/en/pjs.tex
+++ b/v2/tex/en/pjs.tex
@@ -93,7 +93,7 @@ breaking down the Java source code into functional blocks, and then
 mapping each of those blocks to their corresponding JavaScript
 syntax. The result is that, at the cost of
 readability\footnote{Readers are welcome to peruse
-  \url{https://github.com/jeresig/processing-js/blob/v1.3.0/processing.js#L17649},
+  \url{https://github.com/jeresig/processing-js/blob/v1.3.0/processing.js\#L17649},
   up to line 19217.}, Processing.js now effectively contains an
 on-the-fly Java-to-JavaScript transcompiler.
 

--- a/v2/tex/en/yesod.tex
+++ b/v2/tex/en/yesod.tex
@@ -76,7 +76,7 @@ to developers.
 The main architectural challenge in Yesod is balancing these two
 seemingly conflicting goals. For example, there is nothing
 revolutionary about Yesod's approach to routing (called
-\emph{type-safe URLs}\footnote{\url{http://www.yesodweb.com/blog/2012/01/aosa-chapter#file1414-routes}}.
+\emph{type-safe URLs}\footnote{\url{http://www.yesodweb.com/blog/2012/01/aosa-chapter\#file1414-routes}}.
 %% This URL is misbehaving in the PDF, but it looks fine so it
 %% will be okay to print. --ARB
 Historically, implementing such a solution was a tedious, error-prone


### PR DESCRIPTION
Hi,

The generated PDFs lacks of clickable links and does not contains a navigable table of contents. This is annoying.
These two patches restores the use of the LaTeX package `hyperref`.

For the version 1 of the book, no modification was required.
For the version 2, some URLs need to be escaped.

The use of `hyperref` was commented out because it breaks the build, with my patches the PDFs are built correctly.
Let me know if it is not the case for you.