### PR TITLE
Fixed dead link in FreeRTOS chapter in AOSA vol. 1

### DIFF
--- a/aosabook.org/en/freertos.html
+++ b/aosabook.org/en/freertos.html
@@ -822,7 +822,7 @@ priority inheritance for mutexes.</p>
 
 <p>In case you're not familiar with priority inheritance, I'll quote
 Michael Barr again to define it, this time from his article,
-"<a href="http://www.eetimes.com/discussion/beginner-s-corner/4023947/Introduction-to-Priority-Inversion">Introduction to Priority
+"<a href="https://barrgroup.com/Embedded-Systems/How-To/RTOS-Priority-Inversion">Introduction to Priority
 Inversion</a>":</p>
 
 <blockquote>

--- a/v2/epub/source/OEBPS/Text/freertos.html
+++ b/v2/epub/source/OEBPS/Text/freertos.html
@@ -437,7 +437,7 @@ typedef struct QueueDefinition
 
   <p>Since a mutex doesn't store any data in the queue, it doesn't need any internal storage, and so the <code>pcHead</code> and <code>pcTail</code> fields aren't needed. FreeRTOS sets the <code>uxQueueType</code> field (really the <code>pcHead</code> field) to <code>0</code> to note that this queue is being used for a mutex. FreeRTOS uses the overloaded <code>pcTail</code> fields to implement priority inheritance for mutexes.</p>
 
-  <p>In case you're not familiar with priority inheritance, I'll quote Michael Barr again to define it, this time from his article, "<a href="http://www.eetimes.com/discussion/beginner-s-corner/4023947/Introduction-to-Priority-Inversion">Introduction to Priority Inversion</a>":</p>
+  <p>In case you're not familiar with priority inheritance, I'll quote Michael Barr again to define it, this time from his article, "<a href="https://barrgroup.com/Embedded-Systems/How-To/RTOS-Priority-Inversion">Introduction to Priority Inversion</a>":</p>
 
   <blockquote><p>
     [Priority inheritance] mandates that a lower-priority task inherit the priority of any higher-priority task pending on a resource they share. This priority change should take place as soon as the high-priority task begins to pend; it should end when the resource is released.

--- a/v2/tex/en/freertos.tex
+++ b/v2/tex/en/freertos.tex
@@ -748,7 +748,7 @@ priority inheritance for mutexes.
 In case you're not familiar with priority inheritance, I'll quote
 Michael Barr again to define it, this time from his article,
 ``Introduction to Priority
-Inversion''\footnote{\url{http://www.eetimes.com/discussion/beginner-s-corner/4023947/Introduction-to-Priority-Inversion}}:
+Inversion''\footnote{\url{https://barrgroup.com/Embedded-Systems/How-To/RTOS-Priority-Inversion}}:
 
 \begin{quotation}
 \noindent [Priority inheritance] mandates that a lower-priority task inherit the priority 


### PR DESCRIPTION
Just noticed that there is a dead link in the FreeRTOS chapter in the paragraph:

> In case you're not familiar with priority inheritance, I'll quote Michael Barr again to define it, this time from his article, "Introduction to Priority Inversion":

Dead URL: http://www.eetimes.com/discussion/beginner-s-corner/4023947/Introduction-to-Priority-Inversion
Mirror of content: https://barrgroup.com/Embedded-Systems/How-To/RTOS-Priority-Inversion
Working archive.org link: https://web.archive.org/web/20110623191755/http://www.eetimes.com/discussion/beginner-s-corner/4023947/Introduction-to-Priority-Inversion