### PR TITLE
AOSA is not available in EPUB format

### DIFF
--- a/aosabook.org/en/buy.html
+++ b/aosabook.org/en/buy.html
@@ -236,11 +236,11 @@
 		</tr>
 		<tr>
 			<td>
-	     <a class="btn btn-info" href="https://www.lulu.com/shop/greg-wilson-and-amy-brown/the-architecture-of-open-source-applications/ebook/product-15g9wqn7.html">Buy epub</a> 
+	     <a class="btn btn-info" href="https://www.lulu.com/shop/greg-wilson-and-amy-brown/the-architecture-of-open-source-applications/ebook/product-15g9wqn7.html">Buy PDF</a> 
 			</td>
 			<td>
 			     <p> 
-			     	Volume I is available as an epub for US$10.00. If you purchase the epub, Amnesty International will receive	 US$7.21. 
+			     	Volume I is available as a PDF for US$10.00. If you purchase the PDF, Amnesty International will receive	 US$7.21. 
 			   </p>
            </td>
         </tr>


### PR DESCRIPTION
If you actually follow the link for the "epub" of AOSA, you will find
only a PDF available on Lulu.com, so it is misleading for the web site
to claim otherwise. Updating references to an EPUB for that book to PDF
in this commit.