### PR TITLE
v2/yocto: Fix whitespace in example recipe

### DIFF
--- a/src/v2/tex/en/yocto.tex
+++ b/src/v2/tex/en/yocto.tex
@@ -90,23 +90,20 @@ in the Yocto metadata layer.
 \aosafigure[250pt]{../images/yocto/aosa1.jpg}{High-level overview of Poky task execution}{fig.yocto.execution}
 
 \begin{aosabox}{BitBake recipe for \code{grep}}
-
-%% QUERY: I removed a LOT of whitespace from this code - is that okay? --ARB
-%% QUERY: Also removed spaces around "=" in sha256sum line. --ARB
+% This comes from
+% https://git.openembedded.org/openembedded-core/tree/meta/recipes-extended/grep/grep_2.9.bb?id=c11e8c6976903582b37b49ec27327f25e4218e34
 \begin{verbatim}
-
 DESCRIPTION = "GNU grep utility"
 HOMEPAGE = "http://savannah.gnu.org/projects/grep/"
 BUGTRACKER = "http://savannah.gnu.org/bugs/?group=grep"
-
 SECTION = "console/utils"
-
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8006d9c814277c1bfc4ca22af94b59ee"
 
 PR = "r0"
 
 SRC_URI = "${GNU_MIRROR}/grep/grep-${PV}.tar.gz"
+
 SRC_URI[md5sum] = "03e3451a38b0d615cb113cbeaf252dc0"
 SRC_URI[sha256sum]="e9118eac72ecc71191725a7566361ab7643edfd3364869a47b78dc934a357970"
 
@@ -114,10 +111,8 @@ inherit autotools gettext
 
 EXTRA_OECONF = "--disable-perl-regexp"
 
-do_configure_prepend
-() {
-rm
--f ${S}/m4/init.m4
+do_configure_prepend () {
+  rm -f ${S}/m4/init.m4
 }
 
 do_install () {
@@ -128,13 +123,13 @@ do_install () {
   mv ${D}${bindir}/fgrep ${D}${base_bindir}/fgrep.${PN}
 }
 
-pkg_postinst_${PN}() {
+pkg_postinst_${PN} () {
   update-alternatives --install ${base_bindir}/grep grep grep.${PN} 100
   update-alternatives --install ${base_bindir}/egrep egrep egrep.${PN} 100
   update-alternatives --install ${base_bindir}/fgrep fgrep fgrep.${PN} 100
 }
 
-pkg_prerm_${PN}() {
+pkg_prerm_${PN} () {
   update-alternatives --remove grep grep.${PN}
   update-alternatives --remove egrep egrep.${PN}
   update-alternatives --remove fgrep fgrep.${PN}


### PR DESCRIPTION
Adjust the formatting to the original file. This resolves the questions left by ARB.